### PR TITLE
Migrate from LightGraphs to Graphs.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,14 @@
 name = "SimpleWeightedGraphs"
 uuid = "47aef6b3-ad0c-573a-a1e2-d07658019622"
-version = "1.1.1"
+version = "1.2.0"
 
 [deps]
-LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-LightGraphs = "1.3"
+Graphs = "1.4"
 julia = "1"

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 
 **Project Status:** As of 8 October 2021 SimpleWeightedGraphs is no longer under active development. It will remain available on Github at [sbromberger/SimpleWeightedGraphs.jl](https://github.com/sbromberger/SimpleWeightedGraphs.jl). The JuliaGraphs organization will continue to maintain packages that use SimpleWeightedGraphs and transition development over the long term.
 
-Edge-Weighted Graphs for [LightGraphs.jl](https://github.com/JuliaGraphs/LightGraphs.jl).
+Edge-Weighted Graphs for [Graphs.jl](https://github.com/JuliaGraphs/Graphs.jl).
 
 Usage:
 ```julia
-using LightGraphs, SimpleWeightedGraphs
+using Graphs, SimpleWeightedGraphs
 
 g = SimpleWeightedGraph(3)  # or use `SimpleWeightedDiGraph` for directed graphs
 add_edge!(g, 1, 2, 0.5)

--- a/src/SimpleWeightedGraphs.jl
+++ b/src/SimpleWeightedGraphs.jl
@@ -1,6 +1,6 @@
 module SimpleWeightedGraphs
 
-using LightGraphs
+using Graphs
 using LinearAlgebra
 using Markdown
 using SparseArrays
@@ -8,7 +8,7 @@ using SparseArrays
 import Base:
     convert, eltype, show, ==, Pair, Tuple, copy, length, issubset, zero
 
-import LightGraphs:
+import Graphs:
     _NI, AbstractGraph, AbstractEdge, AbstractEdgeIter,
     src, dst, edgetype, nv, ne, vertices, edges, is_directed,
     add_vertex!, add_edge!, rem_vertex!, rem_edge!,

--- a/src/overrides.jl
+++ b/src/overrides.jl
@@ -80,7 +80,7 @@ savegraph(fn::AbstractString, g::AbstractSimpleWeightedGraph, gname::AbstractStr
 savegraph(fn::AbstractString, d::Dict{T, U}; compress=true) where T <: AbstractString where U <: AbstractSimpleWeightedGraph =
     savegraph(fn, d, SWGFormat(), compress=compress)
 
-# It is possible that this is suboptimal, but it is the most trivial extension of the implementation used in LightGraphs
+# It is possible that this is suboptimal, but it is the most trivial extension of the implementation used in Graphs.jl
 function cartesian_product(g::G, h::G) where G <: AbstractSimpleWeightedGraph
     z = G(nv(g) * nv(h))
     id(i, j) = (i - 1) * nv(h) + j

--- a/src/simpleweighteddigraph.jl
+++ b/src/simpleweighteddigraph.jl
@@ -58,7 +58,7 @@ SimpleWeightedDiGraph(::Type{T}) where T<:Integer = SimpleWeightedDiGraph{T, Flo
 SimpleWeightedDiGraph(::Type{T}, ::Type{U}) where {T <: Integer, U <: Real} = SimpleWeightedDiGraph{T, U}(zero(T))
 
 # DiGraph(AbstractGraph, ::Type{U})
-function SimpleWeightedDiGraph(g::LightGraphs.AbstractGraph{T}, ::Type{U}=Float64) where {U <: Real, T}
+function SimpleWeightedDiGraph(g::Graphs.AbstractGraph{T}, ::Type{U}=Float64) where {U <: Real, T}
     return SimpleWeightedDiGraph{T}(adjacency_matrix(g, U))
 end
 
@@ -67,7 +67,7 @@ end
 
 Construct a weighted digraph from other graph `g` with initial weight `x`.
 """
-function SimpleWeightedDiGraph(g::LightGraphs.AbstractGraph{T}, x::U) where {U <: Real, T}
+function SimpleWeightedDiGraph(g::Graphs.AbstractGraph{T}, x::U) where {U <: Real, T}
     m = adjacency_matrix(g, U)'
     return SimpleWeightedDiGraph{T, U}(x .* m, permute=false)
 end
@@ -78,7 +78,7 @@ function SimpleWeightedDiGraph(i::AbstractVector{T}, j::AbstractVector{T}, v::Ab
     SimpleWeightedDiGraph{T, U}(sparse(j, i, v, m, m, combine), permute=false)
 end
 
-LightGraphs.SimpleDiGraph(g::SimpleWeightedDiGraph) = SimpleDiGraph(g.weights')
+Graphs.SimpleDiGraph(g::SimpleWeightedDiGraph) = SimpleDiGraph(g.weights')
 
 edgetype(::SimpleWeightedDiGraph{T, U}) where T<:Integer where U<:Real = SimpleWeightedGraphEdge{T,U}
 

--- a/src/simpleweightededge.jl
+++ b/src/simpleweightededge.jl
@@ -1,5 +1,5 @@
 import Base: Pair, Tuple, show, ==
-import LightGraphs: AbstractEdge, src, dst, reverse
+import Graphs: AbstractEdge, src, dst, reverse
 
 abstract type AbstractSimpleWeightedEdge{T} <: AbstractEdge{T} end
 

--- a/src/simpleweightedgraph.jl
+++ b/src/simpleweightedgraph.jl
@@ -59,20 +59,20 @@ SimpleWeightedGraph(::Type{T}, ::Type{U}) where {T<:Integer, U<:Real} = SimpleWe
 
 # Graph(SimpleGraph)
 
-function SimpleWeightedGraph(g::LightGraphs.AbstractGraph{T}, ::Type{U}=Float64) where {T <: Integer, U <: Real}
-    adj_matrix = if LightGraphs.is_directed(g)
+function SimpleWeightedGraph(g::Graphs.AbstractGraph{T}, ::Type{U}=Float64) where {T <: Integer, U <: Real}
+    adj_matrix = if Graphs.is_directed(g)
         # TODO abstract function instead of SimpleGraph constructor
-        adjacency_matrix(LightGraphs.SimpleGraphs.SimpleGraph(g), U)
+        adjacency_matrix(Graphs.SimpleGraphs.SimpleGraph(g), U)
     else
         adjacency_matrix(g, U)
     end
     return SimpleWeightedGraph{T, U}(adj_matrix)
 end
 
-function SimpleWeightedGraph(g::LightGraphs.AbstractGraph{T}, x::U) where {T <: Integer, U <: Real}
-    adj_matrix = if LightGraphs.is_directed(g)
+function SimpleWeightedGraph(g::Graphs.AbstractGraph{T}, x::U) where {T <: Integer, U <: Real}
+    adj_matrix = if Graphs.is_directed(g)
         # TODO abstract function instead of SimpleGraph constructor
-        adjacency_matrix(LightGraphs.SimpleGraphs.SimpleGraph(g), U)
+        adjacency_matrix(Graphs.SimpleGraphs.SimpleGraph(g), U)
     else
         adjacency_matrix(g, U)
     end
@@ -80,10 +80,10 @@ function SimpleWeightedGraph(g::LightGraphs.AbstractGraph{T}, x::U) where {T <: 
 end
 
 # SimpleWeightedGraph{T, U}(SimpleGraph)
-function (::Type{SimpleWeightedGraph{T, U}})(g::LightGraphs.AbstractGraph)  where {T<:Integer, U <: Real}
-    adj_matrix = if LightGraphs.is_directed(g)
+function (::Type{SimpleWeightedGraph{T, U}})(g::Graphs.AbstractGraph)  where {T<:Integer, U <: Real}
+    adj_matrix = if Graphs.is_directed(g)
         # TODO abstract function instead of SimpleGraph constructor
-        adjacency_matrix(LightGraphs.SimpleGraphs.SimpleGraph{T}(g), U)
+        adjacency_matrix(Graphs.SimpleGraphs.SimpleGraph{T}(g), U)
     else
         adjacency_matrix(g, U)
     end
@@ -97,7 +97,7 @@ function SimpleWeightedGraph(i::AbstractVector{T}, j::AbstractVector{T}, v::Abst
     SimpleWeightedGraph{T, U}(s)
 end
 
-LightGraphs.SimpleGraph(g::SimpleWeightedGraph) = SimpleGraph(g.weights)
+Graphs.SimpleGraph(g::SimpleWeightedGraph) = SimpleGraph(g.weights)
 
 edgetype(::SimpleWeightedGraph{T, U}) where {T<:Integer, U<:Real} = SimpleWeightedGraphEdge{T,U}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using LightGraphs
+using Graphs
 using SimpleWeightedGraphs
 using LinearAlgebra
 using Test
@@ -8,8 +8,8 @@ testdir = dirname(@__FILE__)
 testgraphs(g) = [g, SimpleWeightedGraph{UInt8,Float64}(g), SimpleWeightedGraph{Int16,Float32}(g)]
 testdigraphs(g) = [g, SimpleWeightedDiGraph{UInt8,Float64}(g), SimpleWeightedDiGraph{Int16,Float32}(g)]
 
-testsimplegraphs(g) = [g, LightGraphs.SimpleGraph{UInt8}(g), LightGraphs.SimpleGraph{Int16}(g)]
-testsimpledigraphs(g) = [g, LightGraphs.SimpleDiGraph{UInt8}(g), LightGraphs.SimpleDiGraph{Int16}(g)]
+testsimplegraphs(g) = [g, Graphs.SimpleGraph{UInt8}(g), Graphs.SimpleGraph{Int16}(g)]
+testsimpledigraphs(g) = [g, Graphs.SimpleDiGraph{UInt8}(g), Graphs.SimpleDiGraph{Int16}(g)]
 
 tests = [
     "simpleweightededge",


### PR DESCRIPTION
In `src/persistence.jl` we currently use the string `LightGraphs.SimpleWeightedGraph` as a prefix in files that we persist. I left that as it is, so that we still can load graphs persisted before, Maybe that is something that we can change in the future.