### PR TITLE
Bug fix: Degree matrix build as sparse directly

### DIFF
--- a/src/overrides.jl
+++ b/src/overrides.jl
@@ -24,7 +24,7 @@ function degree_matrix(g::AbstractSimpleWeightedGraph, T::DataType=weighttype(g)
     else
         d = vec(sum(g.weights, dims=1))
     end
-    return SparseMatrixCSC(T.(diagm(0=>d)))
+    return spdiagm( 0 => T.(d) )
 end
 
 function adjacency_matrix(g::AbstractSimpleWeightedGraph, T::DataType=weighttype(g); dir::Symbol=:out)


### PR DESCRIPTION
- The previous implementation builds an intermediate dense matrix for `degree_matrix` formation.