### PR TITLE
remove unbound type parameters

### DIFF
--- a/src/simpleweighteddigraph.jl
+++ b/src/simpleweighteddigraph.jl
@@ -124,7 +124,7 @@ is_directed(::Type{<:SimpleWeightedDiGraph}) = true
 
 Equivalent to g[src(e), dst(e)].
 """
-function Base.getindex(g::SimpleWeightedDiGraph{T, U}, e::AbstractEdge, ::Val{:weight}) where {T, U, S}
+function Base.getindex(g::SimpleWeightedDiGraph{T, U}, e::AbstractEdge, ::Val{:weight}) where {T, U}
     return g.weights[dst(e), src(e)]
 end
 
@@ -133,6 +133,6 @@ end
 
 Return the weight of edge (i, j).
 """
-function Base.getindex(g::SimpleWeightedDiGraph{T, U}, i::Integer, j::Integer, ::Val{:weight}) where {T, U, S}
+function Base.getindex(g::SimpleWeightedDiGraph{T, U}, i::Integer, j::Integer, ::Val{:weight}) where {T, U}
     return g.weights[j, i]
 end

--- a/src/simpleweightedgraph.jl
+++ b/src/simpleweightedgraph.jl
@@ -145,10 +145,10 @@ end
 
 is_directed(::Type{<:SimpleWeightedGraph}) = false
 
-function Base.getindex(g::SimpleWeightedGraph{T, U}, e::AbstractEdge, ::Val{:weight}) where {T, U, S}
+function Base.getindex(g::SimpleWeightedGraph{T, U}, e::AbstractEdge, ::Val{:weight}) where {T, U}
     return g.weights[src(e), dst(e)]
 end
 
-function Base.getindex(g::SimpleWeightedGraph{T, U}, i::Integer, j::Integer, ::Val{:weight}) where {T, U, S}
+function Base.getindex(g::SimpleWeightedGraph{T, U}, i::Integer, j::Integer, ::Val{:weight}) where {T, U}
     return g.weights[i, j]
 end


### PR DESCRIPTION
I didn't check, but unbound type parameters often cause performance issues, so this may not be merely cosmetic.