### PR TITLE
added constructor for SimpleWeightedEdge

### DIFF
--- a/src/simpleweightededge.jl
+++ b/src/simpleweightededge.jl
@@ -15,6 +15,7 @@ SimpleWeightedEdge(p::Pair) = SimpleWeightedEdge(p.first, p.second, one(Float64)
 SimpleWeightedEdge{T, U}(p::Pair) where T<:Integer where U <: Real = SimpleWeightedEdge(T(p.first), T(p.second), one(U))
 SimpleWeightedEdge{T, U}(t::NTuple{3}) where T<:Integer where U <: Real = SimpleWeightedEdge(T(t[1]), T(t[2]), U(t[3]))
 SimpleWeightedEdge{T, U}(t::NTuple{2}) where T<:Integer where U <: Real = SimpleWeightedEdge(T(t[1]), T(t[2]), one(U))
+SimpleWeightedEdge{T, U}(x,y) where T<: Integer where U<:Real = SimpleWeightedEdge(x,y,one(U))
 SimpleWeightedEdge(x, y) = SimpleWeightedEdge(x, y, one(Float64))
 eltype(e::T) where T<:AbstractSimpleWeightedEdge= eltype(src(e))
 

--- a/test/a_star.jl
+++ b/test/a_star.jl
@@ -3,7 +3,7 @@
     add_edge!(g, 1, 2, 0.5)
     add_edge!(g, 2, 3, 0.8)
     add_edge!(g, 1, 3, 2.0)
-    @test_broken length(a_star(g, 1, 3)) == 2
+    @test length(a_star(g, 1, 3)) == 2
     distmx = weights(g)
     heuristic(v) = 0
     edgetype_to_return = Graphs.SimpleEdge

--- a/test/simpleweightedgraph.jl
+++ b/test/simpleweightedgraph.jl
@@ -103,6 +103,9 @@ using SimpleWeightedGraphs
         @test @inferred(copy(g)) == g
         @test @inferred(!is_directed(g))
 
+        # test that edgetype(g) is a valid constructor when called with just the source and destination vertex
+        @test edgetype(g)(1,2) == SimpleWeightedGraphEdge{T, U}(1,2,1.0)
+
         e = first(edges(g))
         @test @inferred(has_edge(g, e))
     end
@@ -171,6 +174,9 @@ using SimpleWeightedGraphs
         @test @inferred(edgetype(g)) == SimpleWeightedDiGraphEdge{T, U}
         @test @inferred(copy(g)) == g
         @test @inferred(is_directed(g))
+
+        # test that edgetype(g) is a valid constructor when called with just the source and destination vertex
+        @test edgetype(g)(1,2) == SimpleWeightedDiGraphEdge{T, U}(1,2,1.0)
 
         e = first(@inferred(edges(g)))
         @test @inferred(has_edge(g, e))


### PR DESCRIPTION
Came across #12 (again) and decided to fix it. I added the appropriate constructor for the `SimpleWeightedEdge` type, added tests to check that it works and "unbroke" the test in A*.