### PR TITLE
Create induced subgraph from edge list

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,8 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Documenter", "Graphs", "JuliaFormatter", "LinearAlgebra", "Test"]
+test = ["Aqua", "Documenter", "Graphs", "JuliaFormatter", "LinearAlgebra", "SparseArrays", "Test"]

--- a/src/overrides.jl
+++ b/src/overrides.jl
@@ -172,20 +172,22 @@ function Graphs.induced_subgraph(
     return newg, Vector{E}(vlist)
 end
 
-function induced_subgraph(g::T, elist::AbstractVector{U}) where T <: AbstractSimpleWeightedGraph where U <: AbstractEdge
+function Graphs.induced_subgraph(
+    g::T, elist::AbstractVector{U}
+) where {T<:AbstractSimpleWeightedGraph} where {U<:AbstractEdge}
     allunique(elist) || throw(ArgumentError("Edges in subgraph list must be unique"))
     E = eltype(g)
     vertex_set = Set{E}()
     @inbounds for e in elist
         if has_edge(g, e)
             push!(vertex_set, src(e), dst(e))
-        else 
+        else
             @warn "Skipping the edge $(e), since it does not exist in the graph!"
         end
     end
     vertex_list = collect(vertex_set)
     sort!(vertex_list)
-    index_map = Dict(vertex_list[i] => i for i=1:length(vertex_list))
+    index_map = Dict(vertex_list[i] => i for i in 1:length(vertex_list))
     n = length(vertex_list)
     new_weights = spzeros(weighttype(g), E, E(n), E(n))
     @inbounds for e in elist
@@ -197,7 +199,6 @@ function induced_subgraph(g::T, elist::AbstractVector{U}) where T <: AbstractSim
             end
         end
     end
-    newg = zero(g)
-    newg.weights = new_weights
+    newg = T(new_weights)
     return newg, Vector{edgetype(g)}(collect(edges(newg)))
 end

--- a/src/overrides.jl
+++ b/src/overrides.jl
@@ -144,3 +144,28 @@ function induced_subgraph(g::T, vlist::AbstractVector{U}) where T <: AbstractSim
     newg.weights = new_weights
     return newg, Vector{E}(vlist)
 end
+
+function induced_subgraph(g::T, elist::AbstractVector{U}) where T <: AbstractSimpleWeightedGraph where U <: AbstractEdge
+    allunique(elist) || throw(ArgumentError("Edges in subgraph list must be unique"))
+    E = eltype(g)
+    W = edgetype(g)
+    vertexSet = Set{E}()
+    for e in elist
+        if has_edge(g, e)
+            push!(vertexSet, src(e), dst(e))
+        else 
+            @warn "Skipping the edge $(e), since it does not exist in the graph!"
+        end
+    end
+    vertexList = collect(vertexSet)
+    new_weights = g.weights[vertexList, vertexList]
+
+    newg = zero(g)
+    newg.weights = new_weights
+    for e in edges(newg)
+        if e ∉ elist
+            newg.weights[dst(e), src(e)] = 0 
+        end
+    end
+    return newg, Vector{W}(collect(edges(newg)))
+end

--- a/test/simpleweightedgraph.jl
+++ b/test/simpleweightedgraph.jl
@@ -1,4 +1,5 @@
 using SimpleWeightedGraphs
+using SparseArrays
 
 @testset verbose = true "SimpleWeightedGraphs" begin
     @info("Ignore warnings relating to adding and removing vertices and edges")
@@ -328,5 +329,19 @@ using SimpleWeightedGraphs
         @test g[1, 2, Val{:weight}()] ≈ 1.1
         @test g[1, 3, Val{:weight}()] ≈ 0
         @test g[2, 3, Val{:weight}()] ≈ 0.5
+    end
+
+    # this testset was implemented for https://github.com/JuliaGraphs/SimpleWeightedGraphs.jl/issues/32
+    @testset "induced_subgraph should preserve weights for edge lists" begin
+        g = SimpleWeightedGraph([0 2; 2 0])
+        graphWeights = weights(g)
+        expectedGraphWeights = sparse([0 2; 2 0])
+        @test graphWeights == expectedGraphWeights
+        # vertex induced subgraph
+        vertexInducedSubgraphWeights = weights(first(induced_subgraph(g, [1, 2])))
+        @test vertexInducedSubgraphWeights == expectedGraphWeights
+        # edge induced subgraph
+        edgeInducedSubgraphWeights = weights(first(induced_subgraph(g, [Edge(1, 2)])))
+        @test edgeInducedSubgraphWeights == expectedGraphWeights
     end
 end

--- a/test/simpleweightedgraph.jl
+++ b/test/simpleweightedgraph.jl
@@ -367,9 +367,13 @@ using SparseArrays
         # test edge induced graph with one edge removed
         # graph isomorphic to C_5
         g = SimpleWeightedGraph([0 2 0 0 2; 2 0 2 0 0; 0 2 0 2 0; 0 0 2 0 2; 2 0 0 2 0])
-        expected_graph_weights = sparse([0 2 0 0 0; 2 0 2 0 0; 0 2 0 2 0; 0 0 2 0 2; 0 0 0 2 0]);
+        expected_graph_weights = sparse(
+            [0 2 0 0 0; 2 0 2 0 0; 0 2 0 2 0; 0 0 2 0 2; 0 0 0 2 0]
+        )
         # create edge induced subgraph isomorphic to P_5. The edge (1, 5) is missing and test if weights are correct.
-        edge_induced_subgraph_weights = weights(first(induced_subgraph(g, [Edge(1, 2), Edge(2, 3), Edge(3, 4), Edge(4, 5)])))
+        edge_induced_subgraph_weights = weights(
+            first(induced_subgraph(g, [Edge(1, 2), Edge(2, 3), Edge(3, 4), Edge(4, 5)]))
+        )
         @test edge_induced_subgraph_weights == expected_graph_weights
 
         # test edge induced subgraph which does not contain the whole vertex set, especially remove the first column (vertex 1)

--- a/test/simpleweightedgraph.jl
+++ b/test/simpleweightedgraph.jl
@@ -334,14 +334,25 @@ using SparseArrays
     # this testset was implemented for https://github.com/JuliaGraphs/SimpleWeightedGraphs.jl/issues/32
     @testset "induced_subgraph should preserve weights for edge lists" begin
         g = SimpleWeightedGraph([0 2; 2 0])
-        graphWeights = weights(g)
-        expectedGraphWeights = sparse([0 2; 2 0])
-        @test graphWeights == expectedGraphWeights
+        expected_graph_weights = sparse([0 2; 2 0])
         # vertex induced subgraph
-        vertexInducedSubgraphWeights = weights(first(induced_subgraph(g, [1, 2])))
-        @test vertexInducedSubgraphWeights == expectedGraphWeights
+        vertex_induced_subgraph_weights = weights(first(induced_subgraph(g, [1, 2])))
+        @test vertex_induced_subgraph_weights == expected_graph_weights
         # edge induced subgraph
-        edgeInducedSubgraphWeights = weights(first(induced_subgraph(g, [Edge(1, 2)])))
-        @test edgeInducedSubgraphWeights == expectedGraphWeights
+        edge_induced_subgraph_weights = weights(first(induced_subgraph(g, [Edge(1, 2)])))
+        @test edge_induced_subgraph_weights == expected_graph_weights
+
+        # test edge induced graph with one edge removed
+        # graph isomorphic to C_5
+        g = SimpleWeightedGraph([0 2 0 0 2; 2 0 2 0 0; 0 2 0 2 0; 0 0 2 0 2; 2 0 0 2 0])
+        expected_graph_weights = sparse([0 2 0 0 0; 2 0 2 0 0; 0 2 0 2 0; 0 0 2 0 2; 0 0 0 2 0]);
+        # create edge induced subgraph isomorphic to P_5. The edge (1, 5) is missing and test if weights are correct.
+        edge_induced_subgraph_weights = weights(first(induced_subgraph(g, [Edge(1, 2), Edge(2, 3), Edge(3, 4), Edge(4, 5)])))
+        @test edge_induced_subgraph_weights == expected_graph_weights
+
+        # test edge induced subgraph which does not contain the whole vertex set, especially remove the first column (vertex 1)
+        edge_induced_subgraph_weights = weights(first(induced_subgraph(g, [Edge(2, 3)])))
+        expected_graph_weights = sparse([0 2; 2 0])
+        @test edge_induced_subgraph_weights == expected_graph_weights
     end
 end


### PR DESCRIPTION
In order to fix [#32](https://github.com/JuliaGraphs/SimpleWeightedGraphs.jl/issues/32), I have added an implementation of the `induced_subgraph` function that creates an edge induced subgraph from a list of edges.