### PR TITLE
Document default direction (`:both`) in `laplacian_matrix` and others

### DIFF
--- a/src/overrides.jl
+++ b/src/overrides.jl
@@ -1,7 +1,7 @@
 """
     degree_matrix(g, T; dir)
 
-Construct the weighted diagonal degree matrix, filled with element type `T` and considering edge direction `dir ∈ [:in, :out, :both]`.
+Construct the weighted diagonal degree matrix, filled with element type `T` and considering edge direction `dir ∈ [:in, :out, :both]` (default is `:out`).
 """
 function degree_matrix(
     g::AbstractSimpleWeightedGraph, T::DataType=weighttype(g); dir::Symbol=:out
@@ -25,7 +25,7 @@ end
 """
     Graphs.adjacency_matrix(g, T; dir)
 
-Construct the weighted adjacency matrix, filled with element type `T` and considering edge direction `dir ∈ [:in, :out, :both]`.
+Construct the weighted adjacency matrix, filled with element type `T` and considering edge direction `dir ∈ [:in, :out, :both]` (default is `:out`).
 """
 function Graphs.adjacency_matrix(
     g::AbstractSimpleWeightedGraph, T::DataType=weighttype(g); dir::Symbol=:out
@@ -40,10 +40,10 @@ end
 """
     Graphs.laplacian_matrix(g, T; dir)
 
-Subtract the adjacency matrix to the degree matrix, both filled with element type `T` and considering edge direction `dir ∈ [:in, :out, :both]`.
+Subtract the adjacency matrix to the degree matrix, both filled with element type `T` and considering edge direction `dir ∈ [:in, :out, :both]` (default is `:both`).
 """
 function Graphs.laplacian_matrix(
-    g::AbstractSimpleWeightedGraph, T::DataType=weighttype(g); dir::Symbol=:out
+    g::AbstractSimpleWeightedGraph, T::DataType=weighttype(g); dir::Symbol=:both
 )
     return degree_matrix(g, T; dir=dir) - adjacency_matrix(g, T; dir=dir)
 end

--- a/src/overrides.jl
+++ b/src/overrides.jl
@@ -40,10 +40,10 @@ end
 """
     Graphs.laplacian_matrix(g, T; dir)
 
-Subtract the adjacency matrix to the degree matrix, both filled with element type `T` and considering edge direction `dir ∈ [:in, :out, :both]` (default is `:both`).
+Subtract the adjacency matrix to the degree matrix, both filled with element type `T` and considering edge direction `dir ∈ [:in, :out, :both]` (unlike in Graphs.jl, default is `:out`).
 """
 function Graphs.laplacian_matrix(
-    g::AbstractSimpleWeightedGraph, T::DataType=weighttype(g); dir::Symbol=:both
+    g::AbstractSimpleWeightedGraph, T::DataType=weighttype(g); dir::Symbol=:out
 )
     return degree_matrix(g, T; dir=dir) - adjacency_matrix(g, T; dir=dir)
 end

--- a/test/overrides.jl
+++ b/test/overrides.jl
@@ -47,7 +47,7 @@
         @test degree_matrix(g, Float64; dir=:out) == degree_matrix(g, Float64; dir=:in)
         @test adjacency_matrix(g)[2, 4] == 0
         @test adjacency_matrix(g; dir=:out) == adjacency_matrix(g; dir=:in)'
-        @test issymmetric(laplacian_matrix(g))
+        @test issymmetric(laplacian_matrix(g; dir=:out))
         @test laplacian_matrix(g, Float64; dir=:out) ≈ g3_l
         @test g[1:3] == SimpleWeightedGraph{eltype(g),weighttype(g)}(path_graph(3))
         gx = copy(g)

--- a/test/overrides.jl
+++ b/test/overrides.jl
@@ -48,7 +48,7 @@
         @test adjacency_matrix(g)[2, 4] == 0
         @test adjacency_matrix(g; dir=:out) == adjacency_matrix(g; dir=:in)'
         @test issymmetric(laplacian_matrix(g))
-        @test laplacian_matrix(g, Float64) ≈ g3_l
+        @test laplacian_matrix(g, Float64; dir=:out) ≈ g3_l
         @test g[1:3] == SimpleWeightedGraph{eltype(g),weighttype(g)}(path_graph(3))
         gx = copy(g)
         add_edge!(gx, 2, 3, 99)
@@ -74,8 +74,8 @@
         @test_throws DomainError degree_matrix(g, dir=:other)
         @test @inferred(adjacency_matrix(g, Int64)) == adjacency_matrix(g, Int64; dir=:out)
         @test adjacency_matrix(g; dir=:out) == adjacency_matrix(g; dir=:in)'
-        @test !issymmetric(laplacian_matrix(g))
-        @test laplacian_matrix(g, Float64) ≈ g5_l
+        @test !issymmetric(laplacian_matrix(g; dir=:out))
+        @test laplacian_matrix(g, Float64; dir=:out) ≈ g5_l
         @test @inferred(pagerank(g))[3] ≈ 0.2266 atol = 0.001
         @test length(@inferred(pagerank(g))) == nv(g)
         @test_throws ErrorException pagerank(g, 2)


### PR DESCRIPTION
Partially solves #24 without breaking backwards compatibility