### PR TITLE
Use `iszero(?)` instead of `?==zero(...)` for warning when adding edge, for Symbolics Num compatibility

### DIFF
--- a/src/simpleweighteddigraph.jl
+++ b/src/simpleweighteddigraph.jl
@@ -163,10 +163,9 @@ Graphs.inneighbors(g::SimpleWeightedDiGraph, v::Integer) = g.weights[v, :].nzind
 # add_edge! will overwrite weights.
 function Graphs.add_edge!(g::SimpleWeightedDiGraph, e::SimpleWeightedGraphEdge)
     T = eltype(g)
-    U = weighttype(g)
     s_, d_, w = Tuple(e)
 
-    if w == zero(U)
+    if iszero(w)
         @warn "Note: adding edges with a zero weight to this graph type has no effect." maxlog =
             1 _id = :swd_add_edge_zero
         return false

--- a/src/simpleweightedgraph.jl
+++ b/src/simpleweightedgraph.jl
@@ -175,10 +175,9 @@ Graphs.inneighbors(g::SimpleWeightedGraph, x...) = outneighbors(g, x...)
 # add_edge! will overwrite weights.
 function Graphs.add_edge!(g::SimpleWeightedGraph, e::SimpleWeightedGraphEdge)
     T = eltype(g)
-    U = weighttype(g)
     s_, d_, w = Tuple(e)
 
-    if w == zero(U)
+    if iszero(w)
         @warn "Note: adding edges with a zero weight to this graph type has no effect." maxlog =
             1 _id = :swg_add_edge_zero
         return false


### PR DESCRIPTION
A partial fix/workaround for #49 with no downsides as far as I can tell. It is just a replacement of comparing to `zero` via `==` to using `iszero`. Though this isn't a comprehensive change to make all things work with Num types, it at least allows their creation (and they seem to mostly work in my usage).